### PR TITLE
Fix class name check when this project is built

### DIFF
--- a/lib/elements/multiselect.js
+++ b/lib/elements/multiselect.js
@@ -21,6 +21,7 @@ const { clear, figures, style, wrap, entriesToDisplay } = require('../util');
 class MultiselectPrompt extends Prompt {
   constructor(opts={}) {
     super(opts);
+    this.isSelect = true;
     this.msg = opts.message;
     // set the cursor to the first non-heading
     this.cursorStart = opts.choices.findIndex(choice => !choice.heading);

--- a/lib/elements/prompt.js
+++ b/lib/elements/prompt.js
@@ -23,9 +23,8 @@ class Prompt extends EventEmitter {
     readline.emitKeypressEvents(this.in, rl);
 
     if (this.in.isTTY) this.in.setRawMode(true);
-    const isSelect = [ 'SelectPrompt', 'MultiselectPrompt' ].indexOf(this.constructor.name) > -1;
     const keypress = (str, key) => {
-      let a = action(key, isSelect);
+      let a = action(key, this.isSelect);
       if (a === false) {
         this._ && this._(str, key);
       } else if (typeof this[a] === 'function') {

--- a/lib/elements/select.js
+++ b/lib/elements/select.js
@@ -19,6 +19,7 @@ const { cursor } = require('sisteransi');
 class SelectPrompt extends Prompt {
   constructor(opts={}) {
     super(opts);
+    this.isSelect = true;
     this.msg = opts.message;
     this.hint = opts.hint || '- Use arrow-keys. Return to submit.';
     this.warn = opts.warn || '- This option is disabled';


### PR DESCRIPTION
When this package is built, the value of `this.constructor.name` is minified (something like "j0") and thus the `indexOf` check always returns false. This change moves it to a property on the class so that the build can't mess with it.

This commit should fix this downstream issue: https://github.com/raineorshine/npm-check-updates/issues/1460

I tested this by manually making the same changes in `node_modules/prompts-ncu` in my local `npm-check-updates` project, rebuilding and then running locally.